### PR TITLE
Sync with latest protocol

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,11 @@
+package main
+
+import "fmt"
+
+type WebsocketSetupHTTPError struct {
+	HttpStatus int
+}
+
+func (e *WebsocketSetupHTTPError) Error() string {
+	return fmt.Sprintf("Server did not respond with expected HTTP status 101 during setup. Actual status=%d", e.HttpStatus)
+}

--- a/http_requests.go
+++ b/http_requests.go
@@ -25,7 +25,7 @@ func connectToWebsocket(wsURL string, reconnectToken uuid.UUID, accessToken stri
 	if err == websocket.ErrBadHandshake {
 		fmt.Printf("%s [ERROR]: Failed to connect to WS url. Handshake status='%d'\n",
 			time.Now().Format(timestampMillisFormat), resp.StatusCode)
-		return nil, err
+		return nil, &WebsocketSetupHTTPError{HttpStatus: resp.StatusCode}
 	} else if err != nil {
 		fmt.Printf("%s [ERROR]: Failed to connect to WS url. Error='%s'\n",
 			time.Now().Format(timestampMillisFormat), err.Error())

--- a/structs.go
+++ b/structs.go
@@ -4,9 +4,8 @@ import uuid "github.com/satori/go.uuid"
 
 // Base for all messages published to end-consumers
 type Message struct {
-	Channel       string    `json:"channel"`
-	SentTimestamp int64     `json:"sent_timestamp"`
-	UUID          uuid.UUID `json:"uuid"`
+	Channel string    `json:"channel"`
+	UUID    uuid.UUID `json:"uuid"`
 }
 
 type PushMessage struct {


### PR DESCRIPTION
Changes in the protocol:
 * `sent_timestamp` attribute has been removed from push messages sent to clients
 * Server returns HTTP status 401 (unauthorized) directly in websocket setup instead of establishing 
    the ws connection, sending custom error code 4001 and then closing it.
 * Server does rate-limiting and can respond with HTTP status 429 on websocket setup. 